### PR TITLE
Condensed User Doc and Training Requirements

### DIFF
--- a/docs/SRS/SRS.tex
+++ b/docs/SRS/SRS.tex
@@ -1319,7 +1319,7 @@ A detailed budget forecast will be developed, encompassing all the aforementione
 
         \subsubsection*{NFR-UD0} 
         \begin{itemize} 
-            \item \textbf{Description}: A built-in help system with a searchable knowledge base, FAQs, user forums and step-by-step guides to assist users with common issues or tasks directly within the platform.  
+            \item \textbf{Description}: A built-in help system with a searchable knowledge base, FAQs, tutorial videos, user forums and step-by-step guides to assist users with common issues or tasks directly within the platform.  
             \item \textbf{Rationale}: An online help system provides quick, on-demand support, improving user experience by minimizing interruptions when seeking assistance.  
             \item \textbf{Fit Criterion}: At least 80\% of users should be able to resolve their issues using the help system without contacting support, as validated by user surveys and support metrics.
         \end{itemize}
@@ -1327,13 +1327,13 @@ A detailed budget forecast will be developed, encompassing all the aforementione
         \begin{itemize} 
             \item \textbf{Description}: A condensed guide offering a quick overview of key platform features and essential workflows to get users started rapidly.  
             \item \textbf{Rationale}: A quick start guide enables new users to become productive immediately without needing to read extensive documentation, improving their onboarding experience.  
-            \item \textbf{Fit Criterion}: At least 90\% of new users should report the quick start guide as helpful, and they should be able to complete a basic labeling task within 15 minutes of using it.
+            \item \textbf{Fit Criterion}: At least 80\% of new users should report the quick start guide as helpful, and they should be able to complete a basic labeling task within 15 minutes of using it.
         \end{itemize}
         \subsubsection*{NFR-UD2} 
         \begin{itemize} 
             \item \textbf{Description}: Provide contextual help directly within the platform, such as tooltips and small info pop-ups, offering real-time guidance for features or form fields as users interact with them.  
             \item \textbf{Rationale}: In-app help reduces the learning curve and provides timely support without requiring users to leave the page or workflow they are on.  
-            \item \textbf{Fit Criterion}: At least 85\% of users should find in-app help intuitive and accurate in providing the necessary support as validated by user surveys.
+            \item \textbf{Fit Criterion}: At least 88\% of users should find in-app help intuitive and accurate in providing the necessary support as validated by user surveys.
         \end{itemize}
 
 
@@ -1344,15 +1344,9 @@ A detailed budget forecast will be developed, encompassing all the aforementione
         \begin{itemize} 
             \item \textbf{Description}: An onboarding tutorial guiding users through key platform functions interactively, offering tooltips and prompts to familiarize them with core workflows.  
             \item \textbf{Rationale}: Interactive onboarding accelerates learning, reduces user frustration, and ensures that new users can quickly perform tasks confidently.  
-            \item \textbf{Fit Criterion}: At least 85\% of users should complete the onboarding tutorial successfully within 20 minutes, with a 90\% rate of positive feedback on its effectiveness.
+            \item \textbf{Fit Criterion}: At least 85\% of users should complete the onboarding tutorial successfully within 20 minutes, with a 80\% rate of positive feedback on its effectiveness.
         \end{itemize}
-        \subsubsection*{NFR-TR1}   
-        \begin{itemize} 
-            \item \textbf{Description}: Short, focused video tutorials covering specific platform tasks (e.g., labeling, account setup) and periodic webinars for in-depth learning and live Q\&A sessions.  
-            \item \textbf{Rationale}: Video content provides a visual and engaging method for users to learn, while webinars offer opportunities for real-time interaction and deeper understanding.  
-            \item \textbf{Fit Criterion}: Each key platform feature should have a corresponding video tutorial, and at least 90\% of webinar attendees should rate the sessions as helpful in post-event feedback.
-        \end{itemize}
-        \subsubsection*{NFR-TR2} 
+        \subsubsection*{NFR-TR1} 
         \begin{itemize} 
             \item \textbf{Description}: A sandbox environment allowing users to practice labeling tasks without affecting live data, including quizzes and exercises to assess understanding and improve skills.  
             \item \textbf{Rationale}: A practice environment enables users to build confidence and hone their skills in a low-pressure setting, ensuring they are prepared for real tasks.  

--- a/docs/SRS/SRS.tex
+++ b/docs/SRS/SRS.tex
@@ -728,20 +728,20 @@ The use case diagram depicted below identifies the boundaries between the users 
 
 \section{Look and Feel Requirements}
 \subsection{Appearance Requirements}
-\subsubsection*{NFR-LF1}
+\subsubsection*{NFR-LF0}
 \begin{itemize}
   \item \textbf{Description:} The application shall adapt to various screen sizes, ensuring legibility and an uncluttered layout.
   \item \textbf{Rationale:} Users will have computers with varying screen sizes, so a consistent experience across all these sizes is ideal.
   \item \textbf{Fit Criterion:} Visual elements must not exceed the boundaries of a screen with a size between the range 1024×768 pixels to 1920×1080 pixels.
 \end{itemize}
-\subsubsection*{NFR-LF2}
+\subsubsection*{NFR-LF1}
 \begin{itemize}
   \item \textbf{Description:} Interactive elements such as buttons shall provide visual feedback to the user.
   \item \textbf{Rationale:} This will allow users a better understanding of when their actions have been processed by the application.
   \item \textbf{Fit Criterion:} Every interactive element changes colour or displays additional visual cues, such as animations or shadows, to indicate interaction.
 \end{itemize}
 \subsection{Style Requirements}
-\subsubsection*{NFR-LF3}
+\subsubsection*{NFR-LF2}
 \begin{itemize}
   \item \textbf{Description:} The application should maintain a unified visual design across all components.
   \item \textbf{Rationale:} A consistent appearance enhances the application's cohesiveness and conveys a professional aesthetic.
@@ -1087,7 +1087,7 @@ N/A
 
 \section{Cultural Requirements}
 \subsection{Cultural Requirements}
-\subsubsection*{NFR-CU1}
+\subsubsection*{NFR-CU0}
 \begin{itemize}
   \item \textbf{Description:} The system shall present users with the option to select the most popular language in each country it is deployed in.
   \item \textbf{Rationale:} It is important that the users of the program can understand what is said in each step.
@@ -1096,19 +1096,19 @@ N/A
 
 \section{Compliance Requirements}
 \subsection{Legal Requirements}
-\subsubsection*{NFR-CO1}
+\subsubsection*{NFR-CO0}
 \begin{itemize}
   \item \textbf{Description:} The system shall not be available in any country currently facing economic sanctions by the Government of Canada.
   \item \textbf{Rationale:} Legal requirement to operate.
   \item \textbf{Fit Criterion:} Website must not be reachable in sanctioned countries. Canadian sanctions are outlined in the following legislation: \href{http://laws-lois.justice.gc.ca/eng/acts/U-2/index.html}{United Nation Act}, \href{http://laws-lois.justice.gc.ca/eng/acts/S-14.5/index.html}{Special Economic Measures Act}, and \href{http://laws.justice.gc.ca/eng/acts/J-2.3/}{Justice for Victims of Corrupt Foreign Officials Act}
 \end{itemize}
-\subsubsection*{NFR-CO2}
+\subsubsection*{NFR-CO1}
 \begin{itemize}
   \item \textbf{Description:} The system shall follow Canadian tax code when accepting and paying out earnings.
   \item \textbf{Rationale:} Legal requirement to operate.
   \item \textbf{Fit Criterion:} All relevant tax codes must be satisfied when accepting payment from Customers or paying out earnings to Labelers. Specifically \href{https://www.ontario.ca/laws/statute/90c40}{Ontario Tax Act, 1990} and \href{https://laws-lois.justice.gc.ca/eng/acts/i-3.3/}{Income Tax Act 1985}
 \end{itemize}
-\subsubsection*{NFR-CO3}
+\subsubsection*{NFR-CO2}
 \begin{itemize}
   \item \textbf{Description:} The system shall allow Customers to restrict Labelers from certain regions from labeling the images related to their service request.
   \item \textbf{Rationale:} Customers may be uploading sensitive images, which are inappropriate for international Labelers to view.

--- a/docs/SRS/SRS.tex
+++ b/docs/SRS/SRS.tex
@@ -995,7 +995,7 @@ N/A
 
 \section{Maintainability and Support Requirements}
 \subsection{Maintenance Requirements}
-\subsubsection*{NFR-MR1}
+\subsubsection*{NFR-MR0}
 \begin{itemize}
   \item \textbf{Description:} All maintainance required for the system shall be possible to complete by a competent software developer after reading all of the documentation provided in the source repository.
   \item \textbf{Rationale:} The system should be well documented, and therefore maintainable after reading said documents.
@@ -1317,37 +1317,19 @@ A detailed budget forecast will be developed, encompassing all the aforementione
 
 \subsection{User Documentation Requirements}
 
-\subsubsection*{NFR-UD0} 
+        \subsubsection*{NFR-UD0} 
         \begin{itemize} 
-            \item \textbf{Description}: A complete user manual detailing all platform functionalities, including system access, navigation, image labeling, and account management, enhanced with visual aids like screenshots for clarity.  
-            \item \textbf{Rationale}: A thorough manual helps users find information independently, reducing support queries and ensuring they can maximize the platform’s potential.  
-            \item \textbf{Fit Criterion}: The manual should cover at least 95\% of the platform's features, and user feedback should reflect a 90\% satisfaction rate in terms of usefulness and comprehensiveness.
-        \end{itemize}
-        \subsubsection*{NFR-UD1} 
-        \begin{itemize} 
-            \item \textbf{Description}: A built-in help system with a searchable knowledge base, FAQs, and step-by-step guides to assist users with common issues or tasks directly within the platform.  
+            \item \textbf{Description}: A built-in help system with a searchable knowledge base, FAQs, user forums and step-by-step guides to assist users with common issues or tasks directly within the platform.  
             \item \textbf{Rationale}: An online help system provides quick, on-demand support, improving user experience by minimizing interruptions when seeking assistance.  
             \item \textbf{Fit Criterion}: At least 80\% of users should be able to resolve their issues using the help system without contacting support, as validated by user surveys and support metrics.
         \end{itemize}
-        \subsubsection*{NFR-UD1} 
-        \begin{itemize} 
-            \item \textbf{Description}: Detailed API documentation using a standard like OpenAPI, covering all endpoints, parameters, response formats, and authentication mechanisms to facilitate integration by external developers.  
-            \item \textbf{Rationale}: Well-documented APIs empower developers to integrate their applications with the platform seamlessly, fostering a wider ecosystem and usage.  
-            \item \textbf{Fit Criterion}: The API documentation should be comprehensive and accurate, with at least 90\% of developer feedback confirming clarity and ease of use.
-        \end{itemize}
-        \subsubsection*{NFR-UD2} 
-        \begin{itemize} 
-            \item \textbf{Description}: Timely release notes detailing new features, bug fixes, and system changes, ensuring users are kept informed about platform improvements and updates.  
-            \item \textbf{Rationale}: Regular release notes maintain transparency, keeping users informed and reducing confusion about new functionality or changes to existing features.  
-            \item \textbf{Fit Criterion}: Each major platform update should be accompanied by release notes, with at least 95\% coverage of changes, and users should report a clear understanding of new features based on feedback.
-        \end{itemize}
-        \subsubsection*{NFR-UD3}   
+        \subsubsection*{NFR-UD1}   
         \begin{itemize} 
             \item \textbf{Description}: A condensed guide offering a quick overview of key platform features and essential workflows to get users started rapidly.  
             \item \textbf{Rationale}: A quick start guide enables new users to become productive immediately without needing to read extensive documentation, improving their onboarding experience.  
             \item \textbf{Fit Criterion}: At least 90\% of new users should report the quick start guide as helpful, and they should be able to complete a basic labeling task within 15 minutes of using it.
         \end{itemize}
-        \subsubsection*{NFR-UD4} 
+        \subsubsection*{NFR-UD2} 
         \begin{itemize} 
             \item \textbf{Description}: Provide contextual help directly within the platform, such as tooltips and small info pop-ups, offering real-time guidance for features or form fields as users interact with them.  
             \item \textbf{Rationale}: In-app help reduces the learning curve and provides timely support without requiring users to leave the page or workflow they are on.  
@@ -1372,27 +1354,9 @@ A detailed budget forecast will be developed, encompassing all the aforementione
         \end{itemize}
         \subsubsection*{NFR-TR2} 
         \begin{itemize} 
-            \item \textbf{Description}: Targeted training materials and sessions tailored to different user groups, such as labelers, clients, and administrators, focusing on their unique needs and platform usage.  
-            \item \textbf{Rationale}: Customized training ensures that users receive relevant guidance, making them more efficient and effective in their roles on the platform.  
-            \item \textbf{Fit Criterion}: At least 90\% of users in specific groups should report that their training materials are relevant to their needs and improve their platform experience.
-        \end{itemize}
-        \subsubsection*{NFR-TR3} 
-        \begin{itemize} 
             \item \textbf{Description}: A sandbox environment allowing users to practice labeling tasks without affecting live data, including quizzes and exercises to assess understanding and improve skills.  
             \item \textbf{Rationale}: A practice environment enables users to build confidence and hone their skills in a low-pressure setting, ensuring they are prepared for real tasks.  
             \item \textbf{Fit Criterion}: At least 80\% of new users should utilize the practice environment, with self-assessment scores indicating an average improvement of 20\% in labeling accuracy over their first three attempts.
-        \end{itemize}
-        \subsubsection*{NFR-TR4}   
-        \begin{itemize} 
-            \item \textbf{Description}: Provide ongoing support through a community forum or discussion board where users can ask questions, share experiences, and learn from one another.  
-            \item \textbf{Rationale}: A support forum fosters a sense of community, provides peer-to-peer assistance, and reduces the load on formal support channels.  
-            \item \textbf{Fit Criterion}: At least 75\% of user questions in the community forum should be answered by either other users or support staff within 2 days.
-        \end{itemize}
-        \subsubsection*{NFR-TR5} 
-        \begin{itemize} 
-            \item \textbf{Description}: Conduct periodic assessments of user knowledge through quizzes or practical tasks to identify training gaps and offer refresher sessions where needed.  
-            \item \textbf{Rationale}: Regular assessments help ensure users retain knowledge and stay up-to-date with platform changes, enhancing overall productivity and satisfaction.  
-            \item \textbf{Fit Criterion}: At least 70\% of users should participate in training assessments, with scores indicating a consistent understanding of platform features and workflows.
         \end{itemize}
 
 


### PR DESCRIPTION
Summary of changes and why:
- Removed requirement about user manual as there is already one about a condensed user manual; I think the latter is more beneficial 
- Removed the requirement about API documentation, in no where before did we specify there would be an API open to the public for this application
- Removed the requirement about timely release notes as that was already covered in release requirements
- Removed the requirement about targeted training materials as I feel we already have enough ways to train, the application should not be overly complex to use
- Integrated the discussion forum requirement into the built in help system
- Integrated the tutorial vids into the built in help system
- Periodic assessment of users seems unnecessary, as of now I don't think the platform would change so much that people would need refreshers on how to use it. Even if they need refreshers, the in app help should suffice 